### PR TITLE
fix: show all notebook in selector - closes #4

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -42,7 +42,7 @@ export const createNotebookList = async () => {
     });
     data.items.forEach((entry: JoplinNote) => out.set(entry.id, entry.title));
   }
-  return out;
+  return Object.fromEntries(out);
 };
 
 // Create HTML options of notebooks

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,11 +26,23 @@ export const setDialogHTML = async (dialog: string) => {
 
 // Get all Notebooks with id and name
 export const createNotebookList = async () => {
-  const folders = await joplin.data.get(["folders"]);
-  return folders.items.reduce(
-    (obj, item) => Object.assign(obj, { [item.id]: item.title }),
-    {}
-  );
+  const out = new Map<string, string>();
+  let pageNum = 1;
+  let data = await joplin.data.get(["folders"], {
+    limit: notes_query_limit,
+    page: pageNum,
+  });
+
+  data.items.forEach((entry) => out.set(entry.id, entry.title));
+  while (data.has_more) {
+    pageNum++;
+    data = await joplin.data.get(["folders"], {
+      limit: notes_query_limit,
+      page: pageNum,
+    });
+    data.items.forEach((entry: JoplinNote) => out.set(entry.id, entry.title));
+  }
+  return out;
 };
 
 // Create HTML options of notebooks


### PR DESCRIPTION
This fixes a bug that not all notebooks are shown when creating a new sync note or setting the default notebook.

Hapend because there was no pagination for many notebooks.

Fixes #4